### PR TITLE
Update bootstrap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,5 +70,5 @@ gem 'cancancan'
 gem 'devise'
 gem 'rolify'
 
-gem 'bootstrap', '~> 4.1.1'
+gem 'bootstrap', '~> 4.1.2'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,14 +45,14 @@ GEM
     addressable (2.4.0)
     arel (9.0.0)
     ast (2.4.0)
-    autoprefixer-rails (8.6.4)
+    autoprefixer-rails (9.1.4)
       execjs
     backports (3.11.3)
     bcrypt (3.1.12)
     bindex (0.5.0)
     bootsnap (1.3.0)
       msgpack (~> 1.0)
-    bootstrap (4.1.1)
+    bootstrap (4.1.3)
       autoprefixer-rails (>= 6.0.3)
       popper_js (>= 1.12.9, < 2)
       sass (>= 3.5.2)
@@ -142,7 +142,7 @@ GEM
     parser (2.5.1.0)
       ast (~> 2.4.0)
     pg (1.0.0)
-    popper_js (1.12.9)
+    popper_js (1.14.3)
     powerpack (0.1.2)
     puma (3.11.4)
     pusher-client (0.6.2)
@@ -279,7 +279,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
-  bootstrap (~> 4.1.1)
+  bootstrap (~> 4.1.2)
   byebug
   cancancan
   coffee-rails (~> 4.2)


### PR DESCRIPTION
Updates bootstrap due to potential security vulnerability:

```
Known moderate severity security vulnerability detected in bootstrap < 4.1.2defined in Gemfile.lock.
--
Gemfile.lock update suggested: bootstrap ~> 4.1.2.
```
